### PR TITLE
Add FastAPI service for demucs separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,11 @@ brew install ffmpeg
 ```
 
 After installing the dependencies you can run stem separation as described
-above.
+above. You can also start a small web service using FastAPI:
+
+```bash
+uvicorn app:app --reload
+```
+
+Upload an audio file with a POST request to `/separate` and the service will
+return a zip archive containing the separated stems.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI, UploadFile, File, BackgroundTasks
+from fastapi.responses import FileResponse
+import tempfile
+import os
+import shutil
+
+from separate_demucs import separate
+
+app = FastAPI(title="AiCapella")
+
+
+def _cleanup(path: str) -> None:
+    """Remove temporary directory."""
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@app.post("/separate")
+async def separate_route(background_tasks: BackgroundTasks, file: UploadFile = File(...)):
+    """Separate uploaded audio file into stems using Demucs."""
+    workdir = tempfile.mkdtemp(prefix="aicapella_")
+    try:
+        audio_path = os.path.join(workdir, file.filename)
+        with open(audio_path, "wb") as f:
+            f.write(await file.read())
+        output_dir = os.path.join(workdir, "stems")
+        separate(audio_path, output_dir)
+        zip_path = shutil.make_archive(os.path.join(workdir, "stems"), "zip", output_dir)
+        background_tasks.add_task(_cleanup, workdir)
+        return FileResponse(zip_path, filename="stems.zip", media_type="application/zip")
+    except Exception:
+        _cleanup(workdir)
+        raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 demucs
+
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- create `app.py` implementing a `/separate` endpoint
- update usage instructions in `README`
- add FastAPI and uvicorn to requirements

## Testing
- `python -m py_compile app.py separate_demucs.py`

------
https://chatgpt.com/codex/tasks/task_e_68427b910a648330a267344fd53a1cea