### PR TITLE
Redirect root path to docs

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import uvicorn
 from fastapi import FastAPI, UploadFile, File, BackgroundTasks
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, RedirectResponse
 import tempfile
 import os
 import shutil
@@ -8,6 +8,12 @@ import shutil
 from separate_demucs import separate
 
 app = FastAPI(title="AiCapella")
+
+
+@app.get("/", include_in_schema=False)
+async def docs_redirect() -> RedirectResponse:
+    """Redirect root path to API documentation."""
+    return RedirectResponse(url="/docs")
 
 
 def _cleanup(path: str) -> None:


### PR DESCRIPTION
## Summary
- redirect `/` to `/docs` so Swagger UI is always visible

## Testing
- `python -m py_compile app.py separate_demucs.py`

------
https://chatgpt.com/codex/tasks/task_e_6843d4c794d08330b48e51d9921b7f59